### PR TITLE
Steps to verify symbols upload

### DIFF
--- a/docs/socorro_test_checklist.rst
+++ b/docs/socorro_test_checklist.rst
@@ -144,6 +144,13 @@ Top Crashers Signature report and Report index
       signature), browse to Report index (by clicking a crash id) to verify
       these work.
 
+Can you upload a symbols file?
+
+    * Download https://github.com/mozilla/socorro/blob/master/webapp-django/crashstats/symbols/tests/sample.zip to disk
+    * Log in with a user with permission to upload symbols.
+    * Go to /symbols/upload/web/
+    * Try to upload it
+    * To verify that it worked, go to the public symbols S3 bucket (e.g. `org.mozilla.crash-stats.staging.symbols-public` in stage) and check that there is a `xpcshell.sym` file in the root with a recent modify date. 
 
 Crontabber
 ==========


### PR DESCRIPTION
I've tested it on stage right now and, sure enough it's causing [a 500 internal server error](https://sentry.prod.mozaws.net/operations/socorro-stage/issues/353294/). It shouldn't. So I think the steps are good for testing. 
